### PR TITLE
fix: encoding uploaded stage file as utf8

### DIFF
--- a/databend_py/uploader.py
+++ b/databend_py/uploader.py
@@ -97,7 +97,7 @@ class DataUploader:
             raise Exception('data is not bytes, File, or a list: %s' % type(data))
         start_time = time.time()
         try:
-            resp = requests.put(presigned_url, headers=headers, data=buf)
+            resp = requests.put(presigned_url, headers=headers, data=buf.encode('utf-8'))
             resp.raise_for_status()
         finally:
             if self._debug:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,6 +198,13 @@ class DatabendPyTestCase(TestCase):
         _, data = client.execute("select NULL as test")
         self.assertIsNone(data[0][0])
 
+    def test_special_chars(self):
+        client = Client.from_url(self.databend_url)
+        client.execute("create or replace table test_special_chars (x string)")
+        client.execute("INSERT INTO test_special_chars (x) VALUES", [('ó')])
+        _, data = client.execute("select * from test_special_chars")
+        self.assertEqual(data, [('ó')])
+
     def test_set_query_id_header(self):
         os.environ["ADDITIONAL_HEADERS"] = "X-DATABENDCLOUD-TENANT=TENANT,X-DATABENDCLOUD-WAREHOUSE=WAREHOUSE"
         client = Client.from_url(self.databend_url)


### PR DESCRIPTION
Run ` c.execute("INSERT INTO example_table (a) VALUES", [('ó')])` will get error like :

```
"code":1046,"message":"Invalid value \'\xef\xbf\xbd\' for column 0 (field_1 String NULL): Invalid Utf8, cause: incomplete utf-8 byte sequence from index 0"
```